### PR TITLE
Build and install info for Ubuntu 13.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,25 @@ Qwertickle is a Linux clone of Qwertick (http://www.nattyware.com/qwertick.php) 
 ## Note
 The sound effect used in this program is from http://www.soundjay.com, any form of redistribution is prohibited.
 
+
+## Build on Ubuntu 13.10 
+1. Install build dependences
+sudo apt-get install autoconf automake libtool libgtk2.0-dev libgstreamer0.10-dev libxtst-dev xorg-dev
+
+2. Update 
+AM_VERSION=-1.14
+to
+AM_VERSION=-1.13
+in autogen.sh
+
+3. run 
+./autogen.sh
+./configure
+make
+
+## Install on Ubuntu 13.10
+1. run
+sudo make install
+
+2. Install mp3 codec for gstreamer
+sudo apt-get install gstreamer0.10-fluendo-mp3 gstreamer1.0-fluendo-mp3


### PR DESCRIPTION
May be this info have to be placed in separate file. In any case it seems to be useful for Ubuntu 13.10 users.
